### PR TITLE
Fix virtual fields

### DIFF
--- a/lib/fixture.js
+++ b/lib/fixture.js
@@ -13,7 +13,7 @@ async function fixture (model, data) {
     // Find or create search associations
     await _executePrerequisiteAssociations(whereAssociations, baseWhere)
 
-    let obj = await model.findOne({ where: baseWhere })
+    let obj = await model.findOne({ where: _removeVirtualAttrs(baseWhere, model) })
     if (obj) {
       // Run sets
       await _executePrerequisiteAssociations(setsAssociations, baseSets)
@@ -36,6 +36,38 @@ async function fixture (model, data) {
   } catch (e) {
     throw e // Breakpoint
   }
+}
+
+/**
+ * Remove virtual attributes from a set of fields.
+ *
+ * If you specify a virtual field in a "where" object, Sequelize will
+ * pass it into the SQL and fail it with "SQLITE_ERROR: no such column".
+ * It needs to be removed from the Where clause when the fixture does
+ * the select lookup.
+ *
+ *  *Hovever*, it works fine if you are INSERTing. In fact, it *should*
+ *  work fine, because you need to be able to use a setter on a virtual
+ *  field to trigger interesting behaviour in the model. (For example, I
+ *  have myself used a virtual field to take a base64-encoded file upload
+ *  and have a beforeValidate trigger to upload it to S3 and save the URL
+ *  back to another field of the model)
+ *
+ * So, we need to remove virtual attributes whenever we are searching for
+ * an existing record, but keep them when we're inserting.
+ *
+ * @param {Object} fields A set of fields to find or create on the model
+ * @param {Sequelize.Model} model Model to check for schema
+ * @return {Object} {fields} with all the virtual attributes taken out
+ */
+function _removeVirtualAttrs (fields, model) {
+  const ret = {}
+  for (let field in fields) {
+    if (model.attributes[field].type.toString() !== 'VIRTUAL') {
+      ret[field] = fields[field]
+    }
+  }
+  return ret
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "clean": "rm ./tmp/*",
     "db": "sqlite3 tmp/testdb.sqlite3",
-    "test": "mocha"
+    "test": "standard && mocha",
+    "test:debug": "mocha --inspect"
   },
   "repository": {
     "type": "git",

--- a/test-files/models/user.js
+++ b/test-files/models/user.js
@@ -14,13 +14,23 @@ module.exports =
       return super.init({
         name: {
           type: Sequelize.STRING,
-          allowNull: false
+          allowNull: false,
+          default: ''
         },
         email: {
           type: Sequelize.STRING,
           allowNull: false,
           validate: {
             isEmail: true
+          }
+        },
+        initial: {
+          type: Sequelize.VIRTUAL,
+          get () {
+            return this.name[0]
+          },
+          set (value) {
+            this.name = value + this.name.substring(1)
           }
         }
       }, { sequelize, timestamps: false })

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -19,7 +19,8 @@ describe('fixture()', function describeFixture () {
       assert.deepEqual(result.get({ plain: true }), {
         id: 1,
         name: 'Amy',
-        email: 'amy@example.com'
+        email: 'amy@example.com',
+        initial: 'A'
       })
     })
 
@@ -50,7 +51,8 @@ describe('fixture()', function describeFixture () {
       assert.deepEqual(result.get({ plain: true }), {
         id: 1,
         name: 'Amy',
-        email: 'amy@example.com'
+        email: 'amy@example.com',
+        initial: 'A'
       })
       const articles = await Post.findAll({ where: { UserId: 1 } })
       assert.deepEqual(
@@ -90,9 +92,16 @@ describe('fixture()', function describeFixture () {
         title: 'Post title',
         body: 'Insightful post',
         UserId: 1,
-        User: { id: 1, name: 'Amy', email: 'amy@example.com' },
+        User: { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' },
         Comments: [{
-          id: 1, title: 'Comment title', body: 'Stupid comment', PostId: 1, UserId: 2, User: { id: 2, name: 'Keith', email: 'keith@example.com' }
+          id: 1,
+          title: 'Comment title',
+          body: 'Stupid comment',
+          PostId: 1,
+          UserId: 2,
+          User: {
+            id: 2, name: 'Keith', email: 'keith@example.com', initial: 'K'
+          }
         }]
       })
     })
@@ -125,9 +134,16 @@ describe('fixture()', function describeFixture () {
         title: 'Post title',
         body: 'Insightful post',
         UserId: 1,
-        User: { id: 1, name: 'Amy', email: 'amy@example.com' },
+        User: { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' },
         Comments: [{
-          id: 1, title: 'Comment title', body: 'Stupid comment', PostId: 1, UserId: 2, User: { id: 2, name: 'Keith', email: 'keith@example.com' }
+          id: 1,
+          title: 'Comment title',
+          body: 'Stupid comment',
+          PostId: 1,
+          UserId: 2,
+          User: {
+            id: 2, name: 'Keith', email: 'keith@example.com', initial: 'K'
+          }
         }]
       })
     })
@@ -140,7 +156,7 @@ describe('fixture()', function describeFixture () {
       })
       assert.deepEqual(
         fixie.get({ plain: true }),
-        { id: 1, name: 'Amy', email: 'amy@example.com' }
+        { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
       )
     })
 
@@ -174,7 +190,7 @@ describe('fixture()', function describeFixture () {
         title: 'Post title',
         body: 'Insightful post',
         UserId: 1,
-        User: { id: 1, name: 'Amy', email: 'amy@example.com' },
+        User: { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' },
         Comments: [
           { id: 1,
             PostId: 1,
@@ -182,7 +198,7 @@ describe('fixture()', function describeFixture () {
             body: 'Thoughtful comment',
             UserId: 1,
             User: {
-              id: 1, name: 'Amy', email: 'amy@example.com'
+              id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A'
             } },
           { id: 2,
             PostId: 1,
@@ -190,7 +206,7 @@ describe('fixture()', function describeFixture () {
             body: 'Sophisticated comment',
             UserId: 1,
             User: {
-              id: 1, name: 'Amy', email: 'amy@example.com'
+              id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A'
             } },
           { id: 3,
             PostId: 1,
@@ -198,7 +214,7 @@ describe('fixture()', function describeFixture () {
             body: 'Ridiculous comment',
             UserId: 2,
             User: {
-              id: 2, name: 'Keith', email: 'keith@example.com'
+              id: 2, name: 'Keith', email: 'keith@example.com', initial: 'K'
             } },
           { id: 4,
             PostId: 1,
@@ -206,7 +222,7 @@ describe('fixture()', function describeFixture () {
             body: 'Amazing comment',
             UserId: 1,
             User: {
-              id: 1, name: 'Amy', email: 'amy@example.com'
+              id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A'
             } }
         ]
       })
@@ -226,6 +242,32 @@ describe('fixture()', function describeFixture () {
         UserId: null
       })
     })
+
+    it('ignores virtual fields for existing records', async function testIgnoreVirtual () {
+      await User.create({ name: 'Amy', email: 'amy@example.com' })
+      const fixie = await fixture(User, {
+        where: { email: 'amy@example.com', initial: 'Q' },
+        defaults: { name: 'Amy' }
+      })
+      assert.deepEqual(
+        fixie.get({ plain: true }),
+        { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
+      )
+    })
+
+    it('pays attention to virtual fields for new records', async function testSetVirtual () {
+      const result = await fixture(User, {
+        name: 'Amy',
+        email: 'amy@example.com',
+        initial: 'R'
+      })
+      assert.deepEqual(result.get({ plain: true }), {
+        id: 1,
+        name: 'Rmy',
+        email: 'amy@example.com',
+        initial: 'R'
+      })
+    })
   })
 
   describe('{ default }', function describeDefaultOption () {
@@ -236,7 +278,7 @@ describe('fixture()', function describeFixture () {
       })
       assert.deepEqual(
         fixie.get({ plain: true }),
-        { id: 1, name: 'Amy', email: 'amy@example.com' }
+        { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
       )
     })
 
@@ -248,7 +290,7 @@ describe('fixture()', function describeFixture () {
       })
       assert.deepEqual(
         fixie.get({ plain: true }),
-        { id: 1, name: 'Amy', email: 'amy@example.com' }
+        { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
       )
     })
   })
@@ -263,13 +305,13 @@ describe('fixture()', function describeFixture () {
       // Set the values in the return obj
       assert.deepEqual(
         fixie.get({ plain: true }),
-        { id: 1, name: 'Aimee', email: 'amy@example.com' }
+        { id: 1, name: 'Aimee', email: 'amy@example.com', initial: 'A' }
       )
       // Set the values in the DB
       const user = await User.findOne({ where: { email: 'amy@example.com' } })
       assert.deepEqual(
         user.get({ plain: true }),
-        { id: 1, name: 'Aimee', email: 'amy@example.com' }
+        { id: 1, name: 'Aimee', email: 'amy@example.com', initial: 'A' }
       )
     })
   })
@@ -283,13 +325,13 @@ describe('fixture()', function describeFixture () {
     // Set the values in the return obj
     assert.deepEqual(
       fixie.get({ plain: true }),
-      { id: 1, name: 'Amy', email: 'amy@example.com' }
+      { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
     )
     // Set the values in the DB
     const user = await User.findOne({ where: { email: 'amy@example.com' } })
     assert.deepEqual(
       user.get({ plain: true }),
-      { id: 1, name: 'Amy', email: 'amy@example.com' }
+      { id: 1, name: 'Amy', email: 'amy@example.com', initial: 'A' }
     )
   })
 })


### PR DESCRIPTION
Virtual fields are now ignored when SELECTing to avoid Sequelize giving us "no such column" errors